### PR TITLE
🩹 [Patch]: Add `Set-GitHubLogGroup` function for logging in GitHub Actions

### DIFF
--- a/scripts/Helpers/Helpers.psm1
+++ b/scripts/Helpers/Helpers.psm1
@@ -1108,3 +1108,58 @@ function Add-PSModulePath {
         Write-Verbose " - [$_]"
     }
 }
+
+function Set-GitHubLogGroup {
+    <#
+        .SYNOPSIS
+        Encapsulates commands with a log group in GitHub Actions
+
+        .DESCRIPTION
+        DSL approach for GitHub Action commands.
+        Allows for colapsing of code in IDE for code that belong together.
+
+        .EXAMPLE
+        Set-GitHubLogGroup -Name 'MyGroup' -ScriptBlock {
+            Write-Host 'Hello, World!'
+        }
+
+        Creates a new log group named 'MyGroup' and writes 'Hello, World!' to the output.
+
+        .EXAMPLE
+        LogGroup 'MyGroup' {
+            Write-Host 'Hello, World!'
+        }
+
+        Uses the alias 'LogGroup' to create a new log group named 'MyGroup' and writes 'Hello, World!' to the output.
+
+        .NOTES
+        [GitHub - Grouping log lines](https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines)
+
+        .LINK
+        https://psmodule.io/GitHub/Functions/Commands/Set-GitHubLogGroup
+    #>
+    [Alias('LogGroup')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function',
+        Justification = 'Does not change state'
+    )]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+        'PSAvoidUsingWriteHost', '', Scope = 'Function',
+        Justification = 'Intended for logging in Github Runners which does support Write-Host'
+    )]
+    [CmdletBinding()]
+    param(
+        # The name of the log group
+        [Parameter(Mandatory)]
+        [string] $Name,
+
+        # The script block to execute
+        [Parameter(Mandatory)]
+        [scriptblock] $ScriptBlock
+    )
+
+    Write-Host "::group::$Name"
+    . $ScriptBlock
+    Write-Host '::endgroup::'
+}
+


### PR DESCRIPTION
## Description

This pull request introduces a new PowerShell function, `Set-GitHubLogGroup`, in the `scripts/Helpers/Helpers.psm1` file. The function provides a DSL approach for grouping log lines in GitHub Actions workflows, improving log organization and readability.

### New functionality for GitHub Actions:

* [`scripts/Helpers/Helpers.psm1`](diffhunk://#diff-4e1a856788c23834d4b062715a48c6a81d985b1f7843a8a7f14fc767e561552fR1111-R1165): Added the `Set-GitHubLogGroup` function, which encapsulates commands within a log group for GitHub Actions. It includes support for creating named log groups using the `-Name` parameter and executing a provided `ScriptBlock`. An alias `LogGroup` is also defined for convenience.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
