### PR TITLE
🩹 [Patch]: Encode all PowerShell files using UTF8 with BOM

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,4 +1,4 @@
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSAvoidUsingWriteHost', '',
     Justification = 'Wriite to the GitHub Actions log, not the pipeline.'
 )]


### PR DESCRIPTION
## Description

This pull request makes a minor update to the `scripts/main.ps1` file, adding a Unicode Byte Order Mark (BOM) at the beginning of the file. No functional code changes were made.