### PR TITLE
⚙️ [Maintenance]: Align workflows across action repositories

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -28,7 +28,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Code
+      - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -34,6 +34,4 @@ jobs:
           persist-credentials: false
 
       - name: Release
-        uses: PSModule/Release-GHRepository@88c70461c8f16cc09682005bcf3b7fca4dd8dc1a # v2.0.1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+        uses: PSModule/Release-GHRepository@5a5165d66f485d1aad217ef34a190178b214fdcb # v2.0.2


### PR DESCRIPTION
This pull request makes a minor update to the release workflow configuration. The main changes are updating the names of steps for clarity and bumping the version of the `PSModule/Release-GHRepository` GitHub Action to ensure the latest fixes and features are used.

- Workflow improvements:
  * Changed the step name from "Checkout Code" to "Checkout repo" for clarity.
  * Updated the `PSModule/Release-GHRepository` action from version `v2.0.1` to `v2.0.2` to use the latest version.